### PR TITLE
Add multi-language support (English, Italian, Dutch)

### DIFF
--- a/src/components/About/About.tsx
+++ b/src/components/About/About.tsx
@@ -3,14 +3,19 @@ import EmailIcon from '@mui/icons-material/Email';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import SchoolIcon from '@mui/icons-material/School';
 import TelegramIcon from '@mui/icons-material/Telegram';
+import { useTranslation } from '../../i18n/context';
 import SocialLink from './SocialLink';
 
 export default function About(): JSX.Element {
+  const { t } = useTranslation();
+
   return (
     <div id="about">
       <div className="grid grid-cols-12 mb-20">
         <div className="ml-[5vw] text-center md:col-span-5 col-span-12">
-          <h2 className="text-6xl mt-20 text-gray-600 underline underline-offset-15">About</h2>
+          <h2 className="text-6xl mt-20 text-gray-600 underline underline-offset-15">
+            {t('about.title')}
+          </h2>
           <img className="rounded-full h-75 mt-10 mx-auto border" src="about/Stefano.png" />
           <div className="mt-10 flex justify-center items-center">
             <SocialLink url="mailto:stefanoborzi32@gmail.com">
@@ -34,34 +39,30 @@ export default function About(): JSX.Element {
               className="bg-gray-800 px-12 py-5 font-medium text-white hover:text-red-400"
               href="StefanoBorzi-CV.pdf"
             >
-              <DescriptionIcon fontSize="medium" className="align-bottom" /> Full Resume
+              <DescriptionIcon fontSize="medium" className="align-bottom" /> {t('about.resume')}
             </a>
             <a
               className="bg-gray-800 px-12 py-5 ml-5 font-medium text-white hover:text-red-400"
               href="StefanoBorzi-CV-Industry.pdf"
             >
-              <DescriptionIcon fontSize="medium" className="align-bottom" /> Industry Resume
+              <DescriptionIcon fontSize="medium" className="align-bottom" />{' '}
+              {t('about.resumeIndustry')}
             </a>
           </div>
         </div>
         <div className="mt-40 md:col-span-6 col-span-12 text-2xl text-gray-600 px-10">
-          <p>I'm a software engineer who started programming for fun at the age of 12.</p>
+          <p>{t('about.p1')}</p>
+          <p className="mt-10">{t('about.p2')}</p>
           <p className="mt-10">
-            I have several years of working experience mostly using web technologies like
-            TypeScript/JavaScript, Angular, NGRX, Redux, React, Next.js, Tailwindcss, Node.js,
-            Python, Bootstrap, HTML, CSS/SCSS, C++, PHP, and Laravel (go to Skills & Projects for a
-            full list).
-          </p>
-          <p className="mt-10">
-            In my spare time, I manage two opensource communities that I have founded{' '}
+            {t('about.p3.before')}
             <a
               className="underline hover:text-black"
               href="https://github.com/azerothcore"
               target="_blank"
             >
               AzerothCore
-            </a>{' '}
-            and{' '}
+            </a>
+            {t('about.p3.and')}
             <a
               className="underline hover:text-black"
               href="https://github.com/unict-dmi"
@@ -73,7 +74,7 @@ export default function About(): JSX.Element {
           </p>
           <p className="mt-10 text-center">
             <img className="inline-block align-middle mr-3" src="about/opensource.png" width="32" />
-            I am really passionate about opensource and Linux.{' '}
+            {t('about.p4')}{' '}
             <img className="inline-block align-middle" src="about/linux-tux.png" width="32" />
           </p>
         </div>

--- a/src/components/Events/Events.tsx
+++ b/src/components/Events/Events.tsx
@@ -1,5 +1,6 @@
 import SmartDisplayIcon from '@mui/icons-material/SmartDisplay';
 import { useState } from 'react';
+import { useTranslation } from '../../i18n/context';
 import Pagination from '../Pagination/Pagination';
 import Talk from './Talk';
 
@@ -153,6 +154,7 @@ const talks: TalkData[] = [
 ];
 
 export default function Events(): JSX.Element {
+  const { t } = useTranslation();
   const [onlyVideo, setOnlyVideo] = useState(false);
   const [onlyGithub, setOnlyGithub] = useState(false);
 
@@ -168,7 +170,7 @@ export default function Events(): JSX.Element {
             <div className="mx-auto md:w-[95%] lg:w-[85%]">
               <div className="pt-10 ml-[5vw] md:ml-[0vw] lg:ml-[0vw]">
                 <h2 className="text-6xl text-white underline underline-offset-15 drop-shadow-[2px_2px_2px_rgba(0,0,0,1)]">
-                  Events
+                  {t('events.title')}
                 </h2>
               </div>
 
@@ -185,7 +187,7 @@ export default function Events(): JSX.Element {
                           className="h-5 w-5 cursor-pointer accent-red-600"
                         />
                         <SmartDisplayIcon className="text-red-600" fontSize="large" />
-                        <span>Video</span>
+                        <span>{t('events.filter.video')}</span>
                       </label>
 
                       <label className="flex items-center gap-2 cursor-pointer select-none">
@@ -196,7 +198,7 @@ export default function Events(): JSX.Element {
                           className="h-5 w-5 cursor-pointer accent-red-600"
                         />
                         <i className="devicon-github-original align-middle text-3xl"></i>
-                        <span>Github</span>
+                        <span>{t('events.filter.github')}</span>
                       </label>
                     </div>
                   </div>

--- a/src/components/Events/Talk.tsx
+++ b/src/components/Events/Talk.tsx
@@ -3,6 +3,7 @@ import DescriptionIcon from '@mui/icons-material/Description';
 import LanguageIcon from '@mui/icons-material/Language';
 import MicIcon from '@mui/icons-material/Mic';
 import SmartDisplayIcon from '@mui/icons-material/SmartDisplay';
+import { useTranslation } from '../../i18n/context';
 
 interface TalkProps {
   image: string;
@@ -27,10 +28,12 @@ export default function Talk({
   github,
   website,
 }: TalkProps): JSX.Element {
+  const { t } = useTranslation();
+
   return (
     <div className="col-span-1 flex flex-col border p-4 bg-gray-800 p-1 m-3 max-h-100 min-h-100">
       <h2 className="text-white text-xl">
-        <strong className="text-red-300">{prefix}</strong> {title}
+        <strong className="text-red-300">{t(prefix)}</strong> {t(title)}
       </h2>
 
       <img src={image} className="mt-2 flex-1 object-contain w-full h-10" />
@@ -39,38 +42,40 @@ export default function Talk({
         {slides && (
           <a href={slides} target="_blank" className="hover:text-gray-400">
             <DescriptionIcon className="align-top" />
-            <span className="underline">slides</span>
+            <span className="underline">{t('talk.slides')}</span>
           </a>
         )}
         {slides && video && ' - '}
         {video && (
           <a href={video} target="_blank" className="hover:text-gray-400">
-            <SmartDisplayIcon className="text-red-600" /> <span className="underline">video</span>
+            <SmartDisplayIcon className="text-red-600" />{' '}
+            <span className="underline">{t('talk.video')}</span>
           </a>
         )}
         {slides && interview && ' - '}
         {interview && (
           <a href={interview} target="_blank" className="hover:text-gray-400">
-            <MicIcon className="text-gray-500" /> <span className="underline">interview </span>
+            <MicIcon className="text-gray-500" />{' '}
+            <span className="underline">{t('talk.interview')} </span>
           </a>
         )}
         {slides && event && ' - '}
         {event && (
           <a href={event} target="_blank" className="hover:text-gray-400">
-            <CalendarMonthIcon /> <span className="underline">event</span>
+            <CalendarMonthIcon /> <span className="underline">{t('talk.event')}</span>
           </a>
         )}
         {(event || slides) && github && ' - '}
         {github && (
           <a href={github} target="_blank" className="hover:text-gray-400">
             <i className="devicon-github-original align-middle py-2 text-2xl"></i>{' '}
-            <span className="underline">github</span>
+            <span className="underline">{t('talk.github')}</span>
           </a>
         )}
         {(github || event) && website && ' - '}
         {website && (
           <a href={website} target="_blank" className="hover:text-gray-400">
-            <LanguageIcon /> <span className="underline">website</span>
+            <LanguageIcon /> <span className="underline">{t('talk.website')}</span>
           </a>
         )}
       </div>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,6 +1,9 @@
 import CopyrightIcon from '@mui/icons-material/Copyright';
+import { useTranslation } from '../../i18n/context';
 
 export default function Footer(): JSX.Element {
+  const { t } = useTranslation();
+
   return (
     <>
       <nav className="bg-gray-800 w-full mb-10">
@@ -10,8 +13,7 @@ export default function Footer(): JSX.Element {
               <div className="hidden sm:ml-6 sm:block">
                 <div className="space-x-4 text-white">
                   <a href="https://github.com/helias/helias.github.io" className="hover:underline">
-                    <CopyrightIcon className="rotate-y-180 align-top" /> Copyleft - All Rights
-                    Reversed
+                    <CopyrightIcon className="rotate-y-180 align-top" /> {t('footer.copyleft')}
                   </a>
                 </div>
               </div>

--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -1,6 +1,9 @@
+import { useTranslation } from '../../i18n/context';
 import TypedText from './Typed-text';
 
 export default function Home(): JSX.Element {
+  const { t } = useTranslation();
+
   return (
     <div className="relative w-full">
       <img
@@ -13,7 +16,7 @@ export default function Home(): JSX.Element {
             Stefano Borzì
           </h1>
           <p className="text-2xl text-white font-bold mt-7 md:ml-45 drop-shadow-[5px_5px_5px_rgba(0,0,0,1)]">
-            I am <TypedText />
+            {t('home.iam')} <TypedText />
           </p>
         </div>
       </div>

--- a/src/components/Home/Typed-text.tsx
+++ b/src/components/Home/Typed-text.tsx
@@ -1,14 +1,18 @@
 import { ReactTyped } from 'react-typed';
+import { useTranslation } from '../../i18n/context';
 
 export default function TypedText(): JSX.Element {
+  const { language, t } = useTranslation();
+
   return (
     <ReactTyped
+      key={language}
       strings={[
-        'an open-source developer',
-        'a tech enthusiast',
-        'a web developer',
-        'a software engineer',
-        'a full-stack developer',
+        t('home.typed.1'),
+        t('home.typed.2'),
+        t('home.typed.3'),
+        t('home.typed.4'),
+        t('home.typed.5'),
       ]}
       typeSpeed={100}
       backSpeed={50}

--- a/src/components/Navbar/LanguageSwitcher.tsx
+++ b/src/components/Navbar/LanguageSwitcher.tsx
@@ -1,0 +1,37 @@
+import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
+import LanguageIcon from '@mui/icons-material/Language';
+import { useTranslation } from '../../i18n/context';
+import { LANGUAGE_FLAGS, LANGUAGE_LABELS, LANGUAGES } from '../../i18n/translations';
+
+export default function LanguageSwitcher(): JSX.Element {
+  const { language, setLanguage } = useTranslation();
+
+  return (
+    <Menu as="div" className="relative">
+      <MenuButton
+        className="flex items-center gap-1 rounded-md px-3 py-2 text-sm font-medium text-gray-300 hover:bg-gray-700 hover:text-white"
+        aria-label="Change language"
+      >
+        <LanguageIcon fontSize="small" />
+        <span>{LANGUAGE_FLAGS[language]}</span>
+        <span className="hidden lg:inline">{LANGUAGE_LABELS[language]}</span>
+      </MenuButton>
+      <MenuItems className="absolute right-0 z-50 mt-2 w-44 origin-top-right rounded-md bg-gray-800 py-1 shadow-lg ring-1 ring-black/30 focus:outline-hidden">
+        {LANGUAGES.map((lang) => (
+          <MenuItem key={lang}>
+            <button
+              type="button"
+              onClick={() => setLanguage(lang)}
+              className={`flex w-full items-center gap-2 px-4 py-2 text-left text-sm data-focus:bg-gray-700 ${
+                lang === language ? 'font-bold text-white' : 'text-gray-300'
+              }`}
+            >
+              <span>{LANGUAGE_FLAGS[lang]}</span>
+              <span>{LANGUAGE_LABELS[lang]}</span>
+            </button>
+          </MenuItem>
+        ))}
+      </MenuItems>
+    </Menu>
+  );
+}

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,15 +1,17 @@
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react';
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
+import { useTranslation } from '../../i18n/context';
+import LanguageSwitcher from './LanguageSwitcher';
 
 const navigation = [
-  { name: 'Home', href: '#home', current: false },
-  { name: 'About', href: '#about', current: false },
-  // { name: 'Experience & Education', href: '#', current: false },
-  { name: 'Skills & Projects', href: '#projects', current: false },
-  { name: 'Opensource', href: '#opensource', current: false },
-  { name: 'Teachings', href: '#teachings', current: false },
-  { name: 'Publications', href: '#publications', current: false },
-  { name: 'Events', href: '#events', current: false },
+  { key: 'nav.home', href: '#home', current: false },
+  { key: 'nav.about', href: '#about', current: false },
+  // { key: 'nav.experience', href: '#', current: false },
+  { key: 'nav.projects', href: '#projects', current: false },
+  { key: 'nav.opensource', href: '#opensource', current: false },
+  { key: 'nav.teachings', href: '#teachings', current: false },
+  { key: 'nav.publications', href: '#publications', current: false },
+  { key: 'nav.events', href: '#events', current: false },
 ];
 
 function classNames(...classes: string[]): string {
@@ -17,6 +19,8 @@ function classNames(...classes: string[]): string {
 }
 
 export default function Navbar(): JSX.Element {
+  const { t } = useTranslation();
+
   return (
     <Disclosure as="nav" className="bg-gray-800 z-100 top-0 sticky w-full border-b-2">
       <div className="mx-auto max-w-7xl px-2 sm:px-6 lg:px-8">
@@ -35,7 +39,7 @@ export default function Navbar(): JSX.Element {
               <div className="flex space-x-4">
                 {navigation.map((item) => (
                   <a
-                    key={item.name}
+                    key={item.key}
                     href={item.href}
                     aria-current={item.current && 'page'}
                     className={classNames(
@@ -45,13 +49,14 @@ export default function Navbar(): JSX.Element {
                       'rounded-md px-3 py-2 text-sm font-medium',
                     )}
                   >
-                    {item.name}
+                    {t(item.key)}
                   </a>
                 ))}
               </div>
             </div>
           </div>
-          <div className="absolute inset-y-0 right-0 flex items-center pr-2 sm:static sm:inset-auto sm:ml-6 sm:pr-0">
+          <div className="absolute inset-y-0 right-0 flex items-center gap-1 pr-2 sm:static sm:inset-auto sm:ml-6 sm:pr-0">
+            <LanguageSwitcher />
             <button
               type="button"
               className="relative rounded-full bg-gray-800 p-1 text-gray-400 hover:text-white focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800 focus:outline-hidden"
@@ -68,7 +73,7 @@ export default function Navbar(): JSX.Element {
         <div className="space-y-1 px-2 pt-2 pb-3">
           {navigation.map((item) => (
             <DisclosureButton
-              key={item.name}
+              key={item.key}
               as="a"
               href={item.href}
               aria-current={item.current && 'page'}
@@ -79,7 +84,7 @@ export default function Navbar(): JSX.Element {
                 'block rounded-md px-3 py-2 text-base font-medium',
               )}
             >
-              {item.name}
+              {t(item.key)}
             </DisclosureButton>
           ))}
         </div>

--- a/src/components/Opensource/Opensource.tsx
+++ b/src/components/Opensource/Opensource.tsx
@@ -1,19 +1,23 @@
+import { useTranslation } from '../../i18n/context';
 import Community from './Community';
 
 export default function Opensource(): JSX.Element {
+  const { t } = useTranslation();
+
   return (
     <div id="opensource" className="bg-gray-800 text-white pt-1">
       <div className="ml-[5vw] md:ml-[10vw] lg:ml-[10vw] pt-10">
-        <h2 className="text-6xl mt-10 underline underline-offset-15">Opensource</h2>
+        <h2 className="text-6xl mt-10 underline underline-offset-15">{t('opensource.title')}</h2>
       </div>
 
       <div className="mx-auto md:w-[80%] lg:w-[75%]">
         <div className="grid grid-cols-12">
           <div className="col-span-12">
             <p className="max-w-300 mx-auto mt-10 text-center p-5 text-2xl">
-              I am deeply passionate about open-source. I've always been involved in various
-              open-source communities, and I have founded two of my own:{' '}
-              <strong>AzerothCore</strong> and <strong>UNICT Devs</strong>.
+              {t('opensource.intro1')}
+              <strong>AzerothCore</strong>
+              {t('opensource.intro2')}
+              <strong>UNICT Devs</strong>.
             </p>
           </div>
         </div>
@@ -22,7 +26,7 @@ export default function Opensource(): JSX.Element {
           <Community
             name="AzerothCore"
             image="opensource/azerothcore.png"
-            description="AzerothCore is an open-source game server application and framework designed for hosting massively multiplayer online role-playing games (MMORPGs). It is based on the popular MMORPG World of Warcraft (WoW) and seeks to recreate the gameplay experience of the original game from patch 3.3.5a."
+            description={t('opensource.azerothcore.desc')}
             organization="azerothcore"
             repository="azerothcore-wotlk"
             extraClass="md:border-gray-50 md:border-r-1 lg:border-gray-50 lg:border-r-1"
@@ -31,7 +35,7 @@ export default function Opensource(): JSX.Element {
           <Community
             name="UNICT-DEVS"
             image="opensource/unict-devs.png"
-            description="UNICT Devs is an open-source community created by students of the Department of Mathematics and Computer Science (DMI) at the University of Catania.It develops and maintains Telegram bots, web apps, and automation tools to enhance university communication, resource sharing, and student services."
+            description={t('opensource.unictdevs.desc')}
             organization="unict-dmi"
             repository="telegram-dmi-bot"
           />

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useEffect, useState } from 'react';
+import { useTranslation } from '../../i18n/context';
 
 interface PaginationProps<T> {
   items: T[];
@@ -20,6 +21,7 @@ export default function Pagination<T>({
   resetKey,
   children,
 }: PaginationProps<T>): JSX.Element {
+  const { t } = useTranslation();
   const [currentPage, setCurrentPage] = useState(1);
 
   useEffect(() => {
@@ -50,7 +52,7 @@ export default function Pagination<T>({
             onClick={() => goToPage(page - 1)}
             disabled={page === 1}
           >
-            Prev
+            {t('pagination.prev')}
           </button>
 
           {Array.from({ length: totalPages }, (_, index) => (
@@ -68,7 +70,7 @@ export default function Pagination<T>({
             onClick={() => goToPage(page + 1)}
             disabled={page === totalPages}
           >
-            Next
+            {t('pagination.next')}
           </button>
         </div>
       </div>

--- a/src/components/Projects/PaginationComponent.tsx
+++ b/src/components/Projects/PaginationComponent.tsx
@@ -6,6 +6,7 @@ import Select, {
   SingleValue,
   SingleValueProps,
 } from 'react-select';
+import { useTranslation } from '../../i18n/context';
 import Pagination from '../Pagination/Pagination';
 import { getIcon } from './helper';
 import Project, { ProjectProps } from './Project';
@@ -37,6 +38,7 @@ const PaginationComponent = ({
   items: ProjectProps[];
   itemsPerPage?: number;
 }) => {
+  const { t } = useTranslation();
   const [currentFilter, setCurrentFilter] = useState(Filter.ALL);
   const [selectedOption, setSelectedOption] = useState<OptionType | null>(null);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -70,19 +72,19 @@ const PaginationComponent = ({
             className={`${sharedNavButtonClasses} ${currentFilter === Filter.ALL ? disableClasses : enableClasses}`}
             onClick={() => setCurrentFilter(Filter.ALL)}
           >
-            All
+            {t('projects.filter.all')}
           </button>
           <button
             className={`${sharedNavButtonClasses} ${currentFilter === Filter.WORK ? disableClasses : enableClasses}`}
             onClick={() => setCurrentFilter(Filter.WORK)}
           >
-            👔 Work
+            {t('projects.filter.work')}
           </button>
           <button
             className={`${sharedNavButtonClasses} ${currentFilter === Filter.OPENSOURCE ? disableClasses : enableClasses}`}
             onClick={() => setCurrentFilter(Filter.OPENSOURCE)}
           >
-            🤝 Opensource
+            {t('projects.filter.opensource')}
           </button>
         </div>
       </div>
@@ -90,7 +92,7 @@ const PaginationComponent = ({
       <div className="col-span-1 mx-auto my-2">
         <div className="min-w-60 text-left mx-5 md:mx-5 lg:mx-0">
           <Select
-            placeholder="Filter by technology"
+            placeholder={t('projects.filterPlaceholder')}
             menuIsOpen={menuOpen}
             onMenuOpen={() => setMenuOpen(true)}
             onMenuClose={() => setMenuOpen(false)}

--- a/src/components/Projects/Project.tsx
+++ b/src/components/Projects/Project.tsx
@@ -1,4 +1,5 @@
 import LanguageIcon from '@mui/icons-material/Language';
+import { useTranslation } from '../../i18n/context';
 import { getIcon } from './helper';
 
 export interface ProjectProps {
@@ -29,6 +30,7 @@ export default function Project({
   customClass = 'bg-top-center',
   menuOpen,
 }: ProjectProps): JSX.Element {
+  const { t } = useTranslation();
   const animationClasses =
     'opacity-0 group-active:opacity-100  group-focus:opacity-100 group-hover:opacity-100 transition-all duration-500 ';
   const bgCover = !customClass.includes('no-bg-cover') && 'bg-cover';
@@ -43,7 +45,7 @@ export default function Project({
     >
       <div className={`h-16 bg-gray-800 flex items-center justify-center p-2 ${animationClasses}`}>
         <h2 className="text-lg text-center text-white my-auto">
-          <strong className="text-red-400">{prefix}</strong> {title}
+          <strong className="text-red-400">{prefix && t(prefix)}</strong> {t(title)}
         </h2>
       </div>
 

--- a/src/components/Projects/ProjectsPage.tsx
+++ b/src/components/Projects/ProjectsPage.tsx
@@ -1,32 +1,27 @@
+import { useTranslation } from '../../i18n/context';
 import { getIcon } from './helper';
 import PaginationComponent from './PaginationComponent';
 import { ProjectList, skillsWeighted } from './ProjectList';
 
 export default function ProjectsPage(): JSX.Element {
+  const { t } = useTranslation();
+
   return (
     <div id="projects">
       <div className="w-full">
         <div className="ml-[5vw] md:ml-[10vw] lg:ml-[10vw] pt-20">
           <h2 className="text-6xl text-gray-600 underline underline-offset-15">
-            Skills & Projects
+            {t('projects.title')}
           </h2>
         </div>
       </div>
 
       <div className="ml-[5vw] md:ml-[10vw] lg:ml-[10vw] mt-10 text-2xl w-[80vw] text-center">
-        I am full-stack developer with a strong focus on front-end development, primarily using
-        Angular. My expertise lies in creating dynamic and responsive web applications, leveraging
-        TypeScript and modern front-end frameworks. Beyond Angular, I have experience with various
-        front-end and back-end technologies. I have also developed several Telegram bots, showcasing
-        my ability to create software solutions that enhance user experience. I contribute on
-        platforms such as Stack Overflow, always looking to share knowledge and refine my skills.
+        {t('projects.intro')}
       </div>
 
       <div className="ml-[5vw] md:ml-[10vw] lg:ml-[10vw] mt-10 text-center w-[80vw]">
-        <p className="text-2xl">
-          The following skills are linked to their size based on the quality and quantity of the
-          projects listed below (note that the order is randomized with each visit).
-        </p>
+        <p className="text-2xl">{t('projects.skillsNote')}</p>
         <div className="mt-10 text-center">
           {skillsWeighted
             .sort(() => Math.random() - 0.5) // shuffle
@@ -38,7 +33,7 @@ export default function ProjectsPage(): JSX.Element {
             ))}
         </div>
         <div className="mt-10 text-center">
-          <strong>All skills & technologies:</strong> Angular, Typescript, Javascript, RxJS, Redux,
+          <strong>{t('projects.allSkills')}</strong> Angular, Typescript, Javascript, RxJS, Redux,
           NGRX, React.js, Next.js, Nx, Cypress, Playwright, Karma, Jasmine, Jest, Webpack, Node.js,
           Nestjs, Expressjs, Three.js, Electron, Websocket, Socketio, PHP, Laravel, Python,
           Selenium, FastAPI, Flask, Pytest, Pytorch, R, C, C++, Java, .NET, Web Components, Micro

--- a/src/components/Publications/Article.tsx
+++ b/src/components/Publications/Article.tsx
@@ -2,6 +2,7 @@ import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import DataObjectIcon from '@mui/icons-material/DataObject';
 import LanguageIcon from '@mui/icons-material/Language';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import { useTranslation } from '../../i18n/context';
 
 interface ArticleProps {
   image: string;
@@ -26,6 +27,8 @@ export default function Article({
   website,
   event,
 }: ArticleProps): JSX.Element {
+  const { t } = useTranslation();
+
   return (
     <div className="col-span-1 flex flex-col border p-4 bg-gray-800 p-1 m-3 max-h-100 min-h-100">
       <h2 className="text-white text-xl">{title}</h2>
@@ -38,32 +41,33 @@ export default function Article({
       <div className="text-white mt-2 text-center">
         {link && (
           <a href={link} target="_blank" className="hover:text-gray-400">
-            <PictureAsPdfIcon className="text-red-400" /> <span className="underline">article</span>
+            <PictureAsPdfIcon className="text-red-400" />{' '}
+            <span className="underline">{t('article.article')}</span>
           </a>
         )}
         {link && cite && ' - '}
         {cite && (
           <a href={cite} target="_blank" className="hover:text-gray-400">
-            <DataObjectIcon /> <span className="underline">cite</span>
+            <DataObjectIcon /> <span className="underline">{t('article.cite')}</span>
           </a>
         )}
         {(link || cite) && event && ' - '}
         {event && (
           <a href={event} target="_blank" className="hover:text-gray-400">
-            <CalendarMonthIcon /> <span className="underline">event</span>
+            <CalendarMonthIcon /> <span className="underline">{t('article.event')}</span>
           </a>
         )}
         {(link || cite || event) && github && ' - '}
         {github && (
           <a href={github} target="_blank" className="hover:text-gray-400">
             <i className="devicon-github-original align-middle py-2 text-2xl"></i>{' '}
-            <span className="underline">github</span>
+            <span className="underline">{t('article.github')}</span>
           </a>
         )}
         {(link || cite || event || github) && website && ' - '}
         {website && (
           <a href={website} target="_blank" className="hover:text-gray-400">
-            <LanguageIcon /> <span className="underline">website</span>
+            <LanguageIcon /> <span className="underline">{t('article.website')}</span>
           </a>
         )}
       </div>

--- a/src/components/Publications/Publications.tsx
+++ b/src/components/Publications/Publications.tsx
@@ -1,11 +1,16 @@
+import { useTranslation } from '../../i18n/context';
 import Article from './Article';
 
 export default function Publications(): JSX.Element {
+  const { t } = useTranslation();
+
   return (
     <div id="publications" className="mb-10 pt-16">
       <div className="w-full">
         <div className="ml-[5vw] md:ml-[10vw] lg:ml-[10vw]">
-          <h2 className="text-6xl text-gray-600 underline underline-offset-15">Publications</h2>
+          <h2 className="text-6xl text-gray-600 underline underline-offset-15">
+            {t('publications.title')}
+          </h2>
         </div>
       </div>
 

--- a/src/components/Teachings/Course.tsx
+++ b/src/components/Teachings/Course.tsx
@@ -1,14 +1,18 @@
+import { useTranslation } from '../../i18n/context';
+
 interface CourseProps {
   name: string;
   link: string;
 }
 
 export default function Course({ name, link }: CourseProps): JSX.Element {
+  const { t } = useTranslation();
+
   return (
     <p className={`text-white text-2xl p-3 w-full md:max-w-130`}>
       - {name} - 🎓{' '}
       <a href={link} target="_blank" className="underline hover:text-gray-400">
-        program
+        {t('teachings.program')}
       </a>{' '}
     </p>
   );

--- a/src/components/Teachings/Teachings.tsx
+++ b/src/components/Teachings/Teachings.tsx
@@ -1,10 +1,13 @@
 import CodeIcon from '@mui/icons-material/Code';
 import DescriptionIcon from '@mui/icons-material/Description';
 import TelegramIcon from '@mui/icons-material/Telegram';
+import { useTranslation } from '../../i18n/context';
 import Course from './Course';
 import CourseLink from './CourseLink';
 
 export default function Teachings(): JSX.Element {
+  const { t } = useTranslation();
+
   return (
     <div id="teachings" className="pt-16 bg-gray-800">
       <div className="bg-[url('/teachings/qd-bg.jpg')] bg-fixed bg-center bg-cover">
@@ -12,7 +15,7 @@ export default function Teachings(): JSX.Element {
           <div className="w-full">
             <div className="ml-[5vw] md:ml-[10vw] lg:ml-[10vw] pt-10">
               <h2 className="text-6xl text-white underline underline-offset-15 drop-shadow-[2px_2px_2px_rgba(0,0,0,1)]">
-                Teachings
+                {t('teachings.title')}
               </h2>
             </div>
 
@@ -54,28 +57,28 @@ export default function Teachings(): JSX.Element {
                     <CourseLink
                       href="https://github.com/UNICT-Quality-Development/"
                       icon={<i className="devicon-github-original align-middle mr-2 text-5xl"></i>}
-                      text="GitHub Organization"
+                      text={t('teachings.link.github')}
                     />
                   </div>
                   <div className="col-span-4 md:col-span-2 lg:col-span-1">
                     <CourseLink
                       href="https://slides.com/stefanoborzi/code"
                       icon={<DescriptionIcon sx={{ fontSize: 50 }} />}
-                      text="Slides"
+                      text={t('teachings.link.slides')}
                     />
                   </div>
                   <div className="col-span-4 md:col-span-2 lg:col-span-1">
                     <CourseLink
                       href="https://unict-quality-development.github.io/git-catalogue/#/"
                       icon={<CodeIcon sx={{ fontSize: 50 }} />}
-                      text="Students Projects"
+                      text={t('teachings.link.projects')}
                     />
                   </div>
                   <div className="col-span-4 md:col-span-2 lg:col-span-1">
                     <CourseLink
                       href="https://t.me/unict_qd"
                       icon={<TelegramIcon sx={{ fontSize: 50 }} className="text-sky-500 mx-2" />}
-                      text="Telegram"
+                      text={t('teachings.link.telegram')}
                     />
                   </div>
                 </div>
@@ -85,10 +88,7 @@ export default function Teachings(): JSX.Element {
             <div className="p-10 mt-30 bg-gray-800">
               <div className="mx-auto md:w-[80%] lg:w-[75%]">
                 <p className="text-white drop-shadow-[2px_2px_2px_rgba(0,0,0,1)] text-2xl">
-                  The course covers topics such as UNIX Shell usage, version control with Git and
-                  GitHub workflows, open-source community engagement, Python programming, unit
-                  testing, code quality principles (ex. SOLID), and Continuous
-                  Integration/Continuous Deployment (CI/CD) tools.
+                  {t('teachings.desc')}
                 </p>
 
                 <div className="mt-5 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-7 place-items-center">

--- a/src/i18n/LanguageContext.tsx
+++ b/src/i18n/LanguageContext.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useMemo, useState } from 'react';
+import { LanguageContext, LanguageContextValue } from './context';
+import { dictionaries, Language, LANGUAGES } from './translations';
+
+const STORAGE_KEY = 'lang';
+
+function isLanguage(value: string | null): value is Language {
+  return value !== null && (LANGUAGES as readonly string[]).includes(value);
+}
+
+function detectInitialLanguage(): Language {
+  if (typeof window === 'undefined') {
+    return 'en';
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (isLanguage(stored)) {
+    return stored;
+  }
+
+  const browser = window.navigator.language?.slice(0, 2).toLowerCase() ?? '';
+  if (isLanguage(browser)) {
+    return browser;
+  }
+
+  return 'en';
+}
+
+export function LanguageProvider({ children }: { children: React.ReactNode }): JSX.Element {
+  const [language, setLanguage] = useState<Language>(detectInitialLanguage);
+
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_KEY, language);
+    document.documentElement.lang = language;
+  }, [language]);
+
+  const value = useMemo<LanguageContextValue>(() => {
+    const t = (key: string): string =>
+      dictionaries[language][key] ?? dictionaries.en[key] ?? key;
+
+    return { language, setLanguage, t };
+  }, [language]);
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
+}

--- a/src/i18n/context.ts
+++ b/src/i18n/context.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react';
+import { Language } from './translations';
+
+export interface LanguageContextValue {
+  readonly language: Language;
+  readonly setLanguage: (language: Language) => void;
+  readonly t: (key: string) => string;
+}
+
+export const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+export function useTranslation(): LanguageContextValue {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    throw new Error('useTranslation must be used within a LanguageProvider');
+  }
+  return context;
+}

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -1,0 +1,498 @@
+export const LANGUAGES = ['en', 'it', 'nl'] as const;
+
+export type Language = (typeof LANGUAGES)[number];
+
+export const LANGUAGE_LABELS: Record<Language, string> = {
+  en: 'English',
+  it: 'Italiano',
+  nl: 'Nederlands',
+};
+
+export const LANGUAGE_FLAGS: Record<Language, string> = {
+  en: '🇬🇧',
+  it: '🇮🇹',
+  nl: '🇳🇱',
+};
+
+type Dictionary = Record<string, string>;
+
+// English is the source language. Content-specific keys (project/talk titles)
+// are keyed by their English string and fall back to the key itself, so only
+// the it/nl dictionaries need to provide their translations.
+const en: Dictionary = {
+  'nav.home': 'Home',
+  'nav.about': 'About',
+  'nav.projects': 'Skills & Projects',
+  'nav.opensource': 'Opensource',
+  'nav.teachings': 'Teachings',
+  'nav.publications': 'Publications',
+  'nav.events': 'Events',
+
+  'home.iam': 'I am',
+  'home.typed.1': 'an open-source developer',
+  'home.typed.2': 'a tech enthusiast',
+  'home.typed.3': 'a web developer',
+  'home.typed.4': 'a software engineer',
+  'home.typed.5': 'a full-stack developer',
+
+  'about.title': 'About',
+  'about.p1': "I'm a software engineer who started programming for fun at the age of 12.",
+  'about.p2':
+    'I have several years of working experience mostly using web technologies like TypeScript/JavaScript, Angular, NGRX, Redux, React, Next.js, Tailwindcss, Node.js, Python, Bootstrap, HTML, CSS/SCSS, C++, PHP, and Laravel (go to Skills & Projects for a full list).',
+  'about.p3.before': 'In my spare time, I manage two opensource communities that I have founded ',
+  'about.p3.and': ' and ',
+  'about.p4': 'I am really passionate about opensource and Linux.',
+  'about.resume': 'Full Resume',
+  'about.resumeIndustry': 'Industry Resume',
+
+  'projects.title': 'Skills & Projects',
+  'projects.intro':
+    'I am full-stack developer with a strong focus on front-end development, primarily using Angular. My expertise lies in creating dynamic and responsive web applications, leveraging TypeScript and modern front-end frameworks. Beyond Angular, I have experience with various front-end and back-end technologies. I have also developed several Telegram bots, showcasing my ability to create software solutions that enhance user experience. I contribute on platforms such as Stack Overflow, always looking to share knowledge and refine my skills.',
+  'projects.skillsNote':
+    'The following skills are linked to their size based on the quality and quantity of the projects listed below (note that the order is randomized with each visit).',
+  'projects.allSkills': 'All skills & technologies:',
+  'projects.filter.all': 'All',
+  'projects.filter.work': '👔 Work',
+  'projects.filter.opensource': '🤝 Opensource',
+  'projects.filterPlaceholder': 'Filter by technology',
+
+  'opensource.title': 'Opensource',
+  'opensource.intro1':
+    "I am deeply passionate about open-source. I've always been involved in various open-source communities, and I have founded two of my own: ",
+  'opensource.intro2': ' and ',
+  'opensource.azerothcore.desc':
+    'AzerothCore is an open-source game server application and framework designed for hosting massively multiplayer online role-playing games (MMORPGs). It is based on the popular MMORPG World of Warcraft (WoW) and seeks to recreate the gameplay experience of the original game from patch 3.3.5a.',
+  'opensource.unictdevs.desc':
+    'UNICT Devs is an open-source community created by students of the Department of Mathematics and Computer Science (DMI) at the University of Catania.It develops and maintains Telegram bots, web apps, and automation tools to enhance university communication, resource sharing, and student services.',
+
+  'teachings.title': 'Teachings',
+  'teachings.program': 'program',
+  'teachings.link.github': 'GitHub Organization',
+  'teachings.link.slides': 'Slides',
+  'teachings.link.projects': 'Students Projects',
+  'teachings.link.telegram': 'Telegram',
+  'teachings.desc':
+    'The course covers topics such as UNIX Shell usage, version control with Git and GitHub workflows, open-source community engagement, Python programming, unit testing, code quality principles (ex. SOLID), and Continuous Integration/Continuous Deployment (CI/CD) tools.',
+
+  'publications.title': 'Publications',
+  'article.article': 'article',
+  'article.cite': 'cite',
+  'article.event': 'event',
+  'article.github': 'github',
+  'article.website': 'website',
+
+  'events.title': 'Events',
+  'events.filter.video': 'Video',
+  'events.filter.github': 'Github',
+  'talk.slides': 'slides',
+  'talk.video': 'video',
+  'talk.interview': 'interview',
+  'talk.event': 'event',
+  'talk.github': 'github',
+  'talk.website': 'website',
+
+  'footer.copyleft': 'Copyleft - All Rights Reversed',
+
+  'pagination.prev': 'Prev',
+  'pagination.next': 'Next',
+};
+
+const it: Dictionary = {
+  'nav.home': 'Home',
+  'nav.about': 'Chi sono',
+  'nav.projects': 'Competenze e Progetti',
+  'nav.opensource': 'Opensource',
+  'nav.teachings': 'Insegnamenti',
+  'nav.publications': 'Pubblicazioni',
+  'nav.events': 'Eventi',
+
+  'home.iam': 'Sono',
+  'home.typed.1': 'uno sviluppatore open-source',
+  'home.typed.2': 'un appassionato di tecnologia',
+  'home.typed.3': 'uno sviluppatore web',
+  'home.typed.4': 'un ingegnere del software',
+  'home.typed.5': 'uno sviluppatore full-stack',
+
+  'about.title': 'Chi sono',
+  'about.p1':
+    "Sono un ingegnere del software che ha iniziato a programmare per divertimento all'età di 12 anni.",
+  'about.p2':
+    "Ho diversi anni di esperienza lavorativa, principalmente con tecnologie web come TypeScript/JavaScript, Angular, NGRX, Redux, React, Next.js, Tailwindcss, Node.js, Python, Bootstrap, HTML, CSS/SCSS, C++, PHP e Laravel (vai a Competenze e Progetti per l'elenco completo).",
+  'about.p3.before': 'Nel tempo libero gestisco due community opensource che ho fondato: ',
+  'about.p3.and': ' e ',
+  'about.p4': 'Sono davvero appassionato di opensource e Linux.',
+  'about.resume': 'Curriculum completo',
+  'about.resumeIndustry': 'Curriculum aziendale',
+
+  'projects.title': 'Competenze e Progetti',
+  'projects.intro':
+    "Sono uno sviluppatore full-stack con una forte attenzione allo sviluppo front-end, principalmente con Angular. La mia specializzazione è la creazione di applicazioni web dinamiche e responsive, sfruttando TypeScript e i moderni framework front-end. Oltre ad Angular, ho esperienza con diverse tecnologie front-end e back-end. Ho inoltre sviluppato diversi bot Telegram, dimostrando la mia capacità di creare soluzioni software che migliorano l'esperienza utente. Contribuisco su piattaforme come Stack Overflow, sempre con l'obiettivo di condividere conoscenza e affinare le mie competenze.",
+  'projects.skillsNote':
+    "Le seguenti competenze hanno una dimensione proporzionale alla qualità e alla quantità dei progetti elencati di seguito (nota che l'ordine è casuale a ogni visita).",
+  'projects.allSkills': 'Tutte le competenze e tecnologie:',
+  'projects.filter.all': 'Tutti',
+  'projects.filter.work': '👔 Lavoro',
+  'projects.filter.opensource': '🤝 Opensource',
+  'projects.filterPlaceholder': 'Filtra per tecnologia',
+
+  'opensource.title': 'Opensource',
+  'opensource.intro1':
+    'Sono profondamente appassionato di open-source. Sono sempre stato coinvolto in varie community open-source e ne ho fondate due mie: ',
+  'opensource.intro2': ' e ',
+  'opensource.azerothcore.desc':
+    "AzerothCore è un'applicazione e framework open-source per server di gioco progettata per ospitare giochi di ruolo online multigiocatore di massa (MMORPG). È basata sul popolare MMORPG World of Warcraft (WoW) e mira a ricreare l'esperienza di gioco originale dalla patch 3.3.5a.",
+  'opensource.unictdevs.desc':
+    "UNICT Devs è una community open-source creata dagli studenti del Dipartimento di Matematica e Informatica (DMI) dell'Università di Catania. Sviluppa e mantiene bot Telegram, applicazioni web e strumenti di automazione per migliorare la comunicazione universitaria, la condivisione delle risorse e i servizi agli studenti.",
+
+  'teachings.title': 'Insegnamenti',
+  'teachings.program': 'programma',
+  'teachings.link.github': 'Organizzazione GitHub',
+  'teachings.link.slides': 'Slide',
+  'teachings.link.projects': 'Progetti degli studenti',
+  'teachings.link.telegram': 'Telegram',
+  'teachings.desc':
+    "Il corso affronta argomenti come l'uso della shell UNIX, il controllo di versione con Git e i workflow di GitHub, la partecipazione alle community open-source, la programmazione in Python, gli unit test, i principi di qualità del codice (es. SOLID) e gli strumenti di Continuous Integration/Continuous Deployment (CI/CD).",
+
+  'publications.title': 'Pubblicazioni',
+  'article.article': 'articolo',
+  'article.cite': 'cita',
+  'article.event': 'evento',
+  'article.github': 'github',
+  'article.website': 'sito web',
+
+  'events.title': 'Eventi',
+  'events.filter.video': 'Video',
+  'events.filter.github': 'Github',
+  'talk.slides': 'slide',
+  'talk.video': 'video',
+  'talk.interview': 'intervista',
+  'talk.event': 'evento',
+  'talk.github': 'github',
+  'talk.website': 'sito web',
+
+  'footer.copyleft': 'Copyleft - Tutti i diritti rovesciati',
+
+  'pagination.prev': 'Prec',
+  'pagination.next': 'Succ',
+
+  // Prefixes (the flag denotes the original talk language and is kept as-is)
+  '👔 Work:': '👔 Lavoro:',
+  '🤝 Opensource:': '🤝 Opensource:',
+  '🇮🇹 Speaker:': '🇮🇹 Relatore:',
+  '🇬🇧 Speaker:': '🇬🇧 Relatore:',
+  '🇮🇹 Panel:': '🇮🇹 Panel:',
+
+  // Project titles
+  'Developed a software management application': "Sviluppata un'applicazione gestionale software",
+  'Developed and mantained the FedEx rating application':
+    "Sviluppata e mantenuta l'applicazione di tariffazione di FedEx",
+  'Developed a web application for InfrontFinance (ex VWD)':
+    "Sviluppata un'applicazione web per InfrontFinance (ex VWD)",
+  'Provided services as freelancer in Fiverr': 'Servizi forniti come freelance su Fiverr',
+  'Software Management for NewTecna & ItaliaHotspot':
+    'Gestionale software per NewTecna e ItaliaHotspot',
+  'Software management developed for Codice a Barre Italia & GirasoleEventi':
+    'Gestionale software sviluppato per Codice a Barre Italia e GirasoleEventi',
+  'Software management developed for PerdichizziGioiellerie':
+    'Gestionale software sviluppato per PerdichizziGioiellerie',
+  'BarcodeDatabase, website for Codice a Barre Italia':
+    'BarcodeDatabase, sito web per Codice a Barre Italia',
+  'Consultant for ItaliaHotspot, developing a web interface, RadiusServer interface and OpenWRT OS':
+    "Consulente per ItaliaHotspot, sviluppo di un'interfaccia web, interfaccia RadiusServer e sistema operativo OpenWRT",
+  'Consultant for Insolaria, developing a web application':
+    "Consulente per Insolaria, sviluppo di un'applicazione web",
+  'Keira3 web application': 'Applicazione web Keira3',
+  'AzerothCore, complete open source and modular solution for MMO':
+    'AzerothCore, soluzione open source completa e modulare per MMO',
+  'Pyhthon Catania website': 'Sito web di Python Catania',
+  'My personal website (this website!)': 'Il mio sito web personale (questo sito!)',
+  'Git-catalogue, a web application to catalog git repositories':
+    "Git-catalogue, un'applicazione web per catalogare repository git",
+  'Car Model Recognition, computer vision application to recognize car models':
+    'Car Model Recognition, applicazione di computer vision per riconoscere i modelli di auto',
+  'Audio feature extractor for synthetic audio detection':
+    'Estrattore di caratteristiche audio per il rilevamento di audio sintetico',
+  'Web application for visualizing audio dataset features.':
+    'Applicazione web per visualizzare le caratteristiche dei dataset audio.',
+  'Server-status, web application': 'Server-status, applicazione web',
+  'Arena-stats, web application': 'Arena-stats, applicazione web',
+  'Acore API, RESTful APIs for Azerothcore written in NestJS':
+    'Acore API, API RESTful per Azerothcore scritte in NestJS',
+  'Telegram automated db backup, tool to backup the database automatically through Telegram':
+    'Backup automatico del database su Telegram, strumento per eseguire automaticamente il backup del database tramite Telegram',
+  'Telegram DMI Bot, a Telegram bot for the University of Catania Department of Mathematician and C.S.':
+    "Telegram DMI Bot, un bot Telegram per il Dipartimento di Matematica e Informatica dell'Università di Catania",
+  'ERSU Bot, telegram bot for the University of Catania':
+    "ERSU Bot, bot Telegram per l'Università di Catania",
+  'Spotted DMI Bot, a Telegram bot for the University of Catania Department of Mathematician and C.S.':
+    "Spotted DMI Bot, un bot Telegram per il Dipartimento di Matematica e Informatica dell'Università di Catania",
+  'MedBot, a Telegram bot for the University of Catania Department of Medicine':
+    "MedBot, un bot Telegram per il Dipartimento di Medicina dell'Università di Catania",
+  'UNICT Telegram Hub, web application to show all the Telegram channels/bots made by UNICT Devs':
+    'UNICT Telegram Hub, applicazione web per mostrare tutti i canali/bot Telegram realizzati da UNICT Devs',
+  'UNICT Telegram Channels Bot, a Telegram bot behind all the University of Catania Telegram channels':
+    "UNICT Telegram Channels Bot, un bot Telegram dietro tutti i canali Telegram dell'Università di Catania",
+  'Albo UNICT Bot, Telegram bot that displays all the research calls from the University of Catania':
+    "Albo UNICT Bot, bot Telegram che mostra tutti i bandi di ricerca dell'Università di Catania",
+  'UNICT-Elezioni, a web application that displays all student elections at the University of Catania':
+    "UNICT-Elezioni, un'applicazione web che mostra tutte le elezioni studentesche dell'Università di Catania",
+  'OPIS Manager, web app to show all the statistics of the University of Catania':
+    "OPIS Manager, web app per mostrare tutte le statistiche dell'Università di Catania",
+  'Robot sensors output 3D viewer': "Visualizzatore 3D dell'output dei sensori del robot",
+  'py-robot-controller, API to control a robot through a web interface and websockets':
+    "py-robot-controller, API per controllare un robot tramite un'interfaccia web e websocket",
+  'wowgaming - AoWoW, database search engine': 'wowgaming - AoWoW, motore di ricerca del database',
+  'World of Warcraft player map': 'Mappa dei giocatori di World of Warcraft',
+  'World of Warcraft statistics web tool': 'Strumento web di statistiche per World of Warcraft',
+  'Slavery Valley, World of Warcraft custom battleground':
+    'Slavery Valley, campo di battaglia personalizzato per World of Warcraft',
+  'Twin Peaks, retroporting of World of Warcraft battleground from Cataclysm to WOTLK':
+    'Twin Peaks, retroporting di un campo di battaglia di World of Warcraft da Cataclysm a WOTLK',
+  'Battle for Gilneas, retroporting of World of Warcraft battleground from Cataclysm to WOTLK':
+    'Battle for Gilneas, retroporting di un campo di battaglia di World of Warcraft da Cataclysm a WOTLK',
+  "Tol' Viron, retropoting of World of Warcraft arena battleground from Pandaria to WOTLK":
+    "Tol' Viron, retroporting di un'arena di World of Warcraft da Pandaria a WOTLK",
+  "Tiger's Peak, retropoting of World of Warcraft arena battleground from Pandaria to WOTLK":
+    "Tiger's Peak, retroporting di un'arena di World of Warcraft da Pandaria a WOTLK",
+  'World of Warcraft 3v3soloQ mod implementation':
+    'Implementazione della mod 3v3soloQ per World of Warcraft',
+  'World of Warcraft Arena Replay mod implementation':
+    'Implementazione della mod Arena Replay per World of Warcraft',
+  'Speech-Gender-Recognition-Bot, for recognizing gender male/female from audio':
+    "Speech-Gender-Recognition-Bot, per riconoscere il genere maschile/femminile dall'audio",
+  'BG Queue Abuser Viewer, single page application to view battleground queue abusers':
+    'BG Queue Abuser Viewer, single page application per visualizzare chi abusa delle code dei campi di battaglia',
+  'Amazon Defense, game built with PhaserJS during a GDG Global Game Jam':
+    'Amazon Defense, gioco realizzato con PhaserJS durante un GDG Global Game Jam',
+  'Sicily social network activities report - web application':
+    'Report delle attività sui social network in Sicilia - applicazione web',
+  'PNG reindexer Bot, a Telegram bot to reindex PNG palette images':
+    'PNG reindexer Bot, un bot Telegram per reindicizzare le immagini PNG con palette',
+  'QR-Scanner-Bot, a Telegram bot to scan easily any QR code':
+    'QR-Scanner-Bot, un bot Telegram per scansionare facilmente qualsiasi codice QR',
+  'EPUB-to-PDF, a Telegram bot that converts EPUB files to PDF':
+    'EPUB-to-PDF, un bot Telegram che converte i file EPUB in PDF',
+  'ImageEditor, editor written in Processing that allows to modify colors channels and apply filters':
+    'ImageEditor, editor scritto in Processing che permette di modificare i canali di colore e applicare filtri',
+  'Android Face Detection app': 'App Android di rilevamento dei volti',
+  'Multi-agent 3D scene simulator with JavaScript preset scripts, built with MEAN.js':
+    'Simulatore di scene 3D multi-agente con script preimpostati in JavaScript, realizzato con MEAN.js',
+
+  // Talk titles (descriptive ones; proper event names are left untranslated)
+  'Best practices and quality code - GDG Catania DevFest 2022':
+    'Best practice e codice di qualità - GDG Catania DevFest 2022',
+  'Is synthetic voice detection research going into the right direction?':
+    'La ricerca sul rilevamento della voce sintetica sta andando nella direzione giusta?',
+  'Saturday Morning Snippets - History of Operating Systems':
+    'Saturday Morning Snippets - Storia dei sistemi operativi',
+  'GenerazioneY Report - Sicily Social Network Report':
+    'GenerazioneY Report - Report sui social network in Sicilia',
+  'Linux Day - Debian-based distros': 'Linux Day - Distribuzioni basate su Debian',
+  'Telegram Bot Talk and Workshop at the Google DevFest 2018':
+    'Talk e workshop sui bot Telegram al Google DevFest 2018',
+  'Telegram Bot Talk at the Google DevFest 2017':
+    'Talk sui bot Telegram al Google DevFest 2017',
+  'Telegram Bot Workshop - Google I/O Extended at the GDG in Catania':
+    'Workshop sui bot Telegram - Google I/O Extended al GDG di Catania',
+};
+
+const nl: Dictionary = {
+  'nav.home': 'Home',
+  'nav.about': 'Over mij',
+  'nav.projects': 'Vaardigheden & Projecten',
+  'nav.opensource': 'Opensource',
+  'nav.teachings': 'Onderwijs',
+  'nav.publications': 'Publicaties',
+  'nav.events': 'Evenementen',
+
+  'home.iam': 'Ik ben',
+  'home.typed.1': 'een opensource-ontwikkelaar',
+  'home.typed.2': 'een techliefhebber',
+  'home.typed.3': 'een webontwikkelaar',
+  'home.typed.4': 'een software-engineer',
+  'home.typed.5': 'een full-stack-ontwikkelaar',
+
+  'about.title': 'Over mij',
+  'about.p1':
+    'Ik ben een software-engineer die op 12-jarige leeftijd voor de lol begon met programmeren.',
+  'about.p2':
+    'Ik heb meerdere jaren werkervaring, voornamelijk met webtechnologieën zoals TypeScript/JavaScript, Angular, NGRX, Redux, React, Next.js, Tailwindcss, Node.js, Python, Bootstrap, HTML, CSS/SCSS, C++, PHP en Laravel (ga naar Vaardigheden & Projecten voor de volledige lijst).',
+  'about.p3.before': 'In mijn vrije tijd beheer ik twee opensource-communities die ik heb opgericht: ',
+  'about.p3.and': ' en ',
+  'about.p4': 'Ik ben echt gepassioneerd door opensource en Linux.',
+  'about.resume': 'Volledig cv',
+  'about.resumeIndustry': 'Industrie-cv',
+
+  'projects.title': 'Vaardigheden & Projecten',
+  'projects.intro':
+    'Ik ben een full-stack-ontwikkelaar met een sterke focus op front-end-ontwikkeling, voornamelijk met Angular. Mijn expertise ligt in het bouwen van dynamische en responsieve webapplicaties met TypeScript en moderne front-end-frameworks. Naast Angular heb ik ervaring met diverse front-end- en back-end-technologieën. Ik heb ook verschillende Telegram-bots ontwikkeld, wat mijn vermogen toont om softwareoplossingen te maken die de gebruikerservaring verbeteren. Ik draag bij aan platforms zoals Stack Overflow, altijd op zoek om kennis te delen en mijn vaardigheden te verfijnen.',
+  'projects.skillsNote':
+    'De volgende vaardigheden hebben een grootte die gebaseerd is op de kwaliteit en kwantiteit van de hieronder vermelde projecten (de volgorde wordt bij elk bezoek willekeurig bepaald).',
+  'projects.allSkills': 'Alle vaardigheden & technologieën:',
+  'projects.filter.all': 'Alle',
+  'projects.filter.work': '👔 Werk',
+  'projects.filter.opensource': '🤝 Opensource',
+  'projects.filterPlaceholder': 'Filter op technologie',
+
+  'opensource.title': 'Opensource',
+  'opensource.intro1':
+    'Ik ben enorm gepassioneerd door opensource. Ik ben altijd betrokken geweest bij verschillende opensource-communities en heb er twee van mezelf opgericht: ',
+  'opensource.intro2': ' en ',
+  'opensource.azerothcore.desc':
+    "AzerothCore is een opensource-gameserverapplicatie en -framework, ontworpen voor het hosten van massively multiplayer online rollenspellen (MMORPG's). Het is gebaseerd op het populaire MMORPG World of Warcraft (WoW) en probeert de speelervaring van het originele spel uit patch 3.3.5a na te bootsen.",
+  'opensource.unictdevs.desc':
+    'UNICT Devs is een opensource-community opgericht door studenten van de afdeling Wiskunde en Informatica (DMI) van de Universiteit van Catania. De community ontwikkelt en onderhoudt Telegram-bots, webapps en automatiseringstools om de universitaire communicatie, het delen van bronnen en de studentenservices te verbeteren.',
+
+  'teachings.title': 'Onderwijs',
+  'teachings.program': 'programma',
+  'teachings.link.github': 'GitHub-organisatie',
+  'teachings.link.slides': 'Slides',
+  'teachings.link.projects': 'Studentenprojecten',
+  'teachings.link.telegram': 'Telegram',
+  'teachings.desc':
+    'De cursus behandelt onderwerpen zoals het gebruik van de UNIX-shell, versiebeheer met Git en GitHub-workflows, betrokkenheid bij opensource-communities, programmeren in Python, unit testing, principes voor codekwaliteit (bijv. SOLID) en tools voor Continuous Integration/Continuous Deployment (CI/CD).',
+
+  'publications.title': 'Publicaties',
+  'article.article': 'artikel',
+  'article.cite': 'citeren',
+  'article.event': 'evenement',
+  'article.github': 'github',
+  'article.website': 'website',
+
+  'events.title': 'Evenementen',
+  'events.filter.video': 'Video',
+  'events.filter.github': 'Github',
+  'talk.slides': 'slides',
+  'talk.video': 'video',
+  'talk.interview': 'interview',
+  'talk.event': 'evenement',
+  'talk.github': 'github',
+  'talk.website': 'website',
+
+  'footer.copyleft': 'Copyleft - Alle rechten omgekeerd',
+
+  'pagination.prev': 'Vorige',
+  'pagination.next': 'Volgende',
+
+  // Prefixes (the flag denotes the original talk language and is kept as-is)
+  '👔 Work:': '👔 Werk:',
+  '🤝 Opensource:': '🤝 Opensource:',
+  '🇮🇹 Speaker:': '🇮🇹 Spreker:',
+  '🇬🇧 Speaker:': '🇬🇧 Spreker:',
+  '🇮🇹 Panel:': '🇮🇹 Panel:',
+
+  // Project titles
+  'Developed a software management application': 'Een softwarebeheerapplicatie ontwikkeld',
+  'Developed and mantained the FedEx rating application':
+    'De FedEx-tariefapplicatie ontwikkeld en onderhouden',
+  'Developed a web application for InfrontFinance (ex VWD)':
+    'Een webapplicatie ontwikkeld voor InfrontFinance (voorheen VWD)',
+  'Provided services as freelancer in Fiverr': 'Diensten geleverd als freelancer op Fiverr',
+  'Software Management for NewTecna & ItaliaHotspot':
+    'Softwarebeheer voor NewTecna & ItaliaHotspot',
+  'Software management developed for Codice a Barre Italia & GirasoleEventi':
+    'Softwarebeheer ontwikkeld voor Codice a Barre Italia & GirasoleEventi',
+  'Software management developed for PerdichizziGioiellerie':
+    'Softwarebeheer ontwikkeld voor PerdichizziGioiellerie',
+  'BarcodeDatabase, website for Codice a Barre Italia':
+    'BarcodeDatabase, website voor Codice a Barre Italia',
+  'Consultant for ItaliaHotspot, developing a web interface, RadiusServer interface and OpenWRT OS':
+    'Consultant voor ItaliaHotspot, ontwikkeling van een webinterface, RadiusServer-interface en OpenWRT-besturingssysteem',
+  'Consultant for Insolaria, developing a web application':
+    'Consultant voor Insolaria, ontwikkeling van een webapplicatie',
+  'Keira3 web application': 'Keira3-webapplicatie',
+  'AzerothCore, complete open source and modular solution for MMO':
+    'AzerothCore, complete opensource en modulaire oplossing voor MMO',
+  'Pyhthon Catania website': 'Website van Python Catania',
+  'My personal website (this website!)': 'Mijn persoonlijke website (deze website!)',
+  'Git-catalogue, a web application to catalog git repositories':
+    'Git-catalogue, een webapplicatie om git-repositories te catalogiseren',
+  'Car Model Recognition, computer vision application to recognize car models':
+    'Car Model Recognition, computervisietoepassing om automodellen te herkennen',
+  'Audio feature extractor for synthetic audio detection':
+    'Audiokenmerk-extractor voor de detectie van synthetische audio',
+  'Web application for visualizing audio dataset features.':
+    'Webapplicatie voor het visualiseren van kenmerken van audiodatasets.',
+  'Server-status, web application': 'Server-status, webapplicatie',
+  'Arena-stats, web application': 'Arena-stats, webapplicatie',
+  'Acore API, RESTful APIs for Azerothcore written in NestJS':
+    "Acore API, RESTful API's voor Azerothcore geschreven in NestJS",
+  'Telegram automated db backup, tool to backup the database automatically through Telegram':
+    'Geautomatiseerde db-back-up via Telegram, tool om de database automatisch via Telegram te back-uppen',
+  'Telegram DMI Bot, a Telegram bot for the University of Catania Department of Mathematician and C.S.':
+    'Telegram DMI Bot, een Telegram-bot voor de afdeling Wiskunde en Informatica van de Universiteit van Catania',
+  'ERSU Bot, telegram bot for the University of Catania':
+    'ERSU Bot, Telegram-bot voor de Universiteit van Catania',
+  'Spotted DMI Bot, a Telegram bot for the University of Catania Department of Mathematician and C.S.':
+    'Spotted DMI Bot, een Telegram-bot voor de afdeling Wiskunde en Informatica van de Universiteit van Catania',
+  'MedBot, a Telegram bot for the University of Catania Department of Medicine':
+    'MedBot, een Telegram-bot voor de afdeling Geneeskunde van de Universiteit van Catania',
+  'UNICT Telegram Hub, web application to show all the Telegram channels/bots made by UNICT Devs':
+    'UNICT Telegram Hub, webapplicatie om alle Telegram-kanalen/bots van UNICT Devs te tonen',
+  'UNICT Telegram Channels Bot, a Telegram bot behind all the University of Catania Telegram channels':
+    'UNICT Telegram Channels Bot, een Telegram-bot achter alle Telegram-kanalen van de Universiteit van Catania',
+  'Albo UNICT Bot, Telegram bot that displays all the research calls from the University of Catania':
+    'Albo UNICT Bot, Telegram-bot die alle onderzoeksoproepen van de Universiteit van Catania weergeeft',
+  'UNICT-Elezioni, a web application that displays all student elections at the University of Catania':
+    'UNICT-Elezioni, een webapplicatie die alle studentenverkiezingen aan de Universiteit van Catania weergeeft',
+  'OPIS Manager, web app to show all the statistics of the University of Catania':
+    'OPIS Manager, webapp om alle statistieken van de Universiteit van Catania te tonen',
+  'Robot sensors output 3D viewer': '3D-viewer voor de sensoruitvoer van een robot',
+  'py-robot-controller, API to control a robot through a web interface and websockets':
+    'py-robot-controller, API om een robot te besturen via een webinterface en websockets',
+  'wowgaming - AoWoW, database search engine': 'wowgaming - AoWoW, zoekmachine voor de database',
+  'World of Warcraft player map': 'Spelerskaart voor World of Warcraft',
+  'World of Warcraft statistics web tool': 'Webtool voor World of Warcraft-statistieken',
+  'Slavery Valley, World of Warcraft custom battleground':
+    'Slavery Valley, aangepast strijdveld voor World of Warcraft',
+  'Twin Peaks, retroporting of World of Warcraft battleground from Cataclysm to WOTLK':
+    'Twin Peaks, retroporting van een World of Warcraft-strijdveld van Cataclysm naar WOTLK',
+  'Battle for Gilneas, retroporting of World of Warcraft battleground from Cataclysm to WOTLK':
+    'Battle for Gilneas, retroporting van een World of Warcraft-strijdveld van Cataclysm naar WOTLK',
+  "Tol' Viron, retropoting of World of Warcraft arena battleground from Pandaria to WOTLK":
+    "Tol' Viron, retroporting van een World of Warcraft-arena van Pandaria naar WOTLK",
+  "Tiger's Peak, retropoting of World of Warcraft arena battleground from Pandaria to WOTLK":
+    "Tiger's Peak, retroporting van een World of Warcraft-arena van Pandaria naar WOTLK",
+  'World of Warcraft 3v3soloQ mod implementation':
+    'Implementatie van de 3v3soloQ-mod voor World of Warcraft',
+  'World of Warcraft Arena Replay mod implementation':
+    'Implementatie van de Arena Replay-mod voor World of Warcraft',
+  'Speech-Gender-Recognition-Bot, for recognizing gender male/female from audio':
+    'Speech-Gender-Recognition-Bot, om mannelijk/vrouwelijk geslacht uit audio te herkennen',
+  'BG Queue Abuser Viewer, single page application to view battleground queue abusers':
+    'BG Queue Abuser Viewer, single-page-applicatie om misbruikers van de strijdveldwachtrij te bekijken',
+  'Amazon Defense, game built with PhaserJS during a GDG Global Game Jam':
+    'Amazon Defense, game gebouwd met PhaserJS tijdens een GDG Global Game Jam',
+  'Sicily social network activities report - web application':
+    'Rapport over socialemedia-activiteiten in Sicilië - webapplicatie',
+  'PNG reindexer Bot, a Telegram bot to reindex PNG palette images':
+    'PNG reindexer Bot, een Telegram-bot om PNG-paletafbeeldingen opnieuw te indexeren',
+  'QR-Scanner-Bot, a Telegram bot to scan easily any QR code':
+    'QR-Scanner-Bot, een Telegram-bot om eenvoudig elke QR-code te scannen',
+  'EPUB-to-PDF, a Telegram bot that converts EPUB files to PDF':
+    'EPUB-to-PDF, een Telegram-bot die EPUB-bestanden naar PDF converteert',
+  'ImageEditor, editor written in Processing that allows to modify colors channels and apply filters':
+    'ImageEditor, editor geschreven in Processing waarmee je kleurkanalen kunt aanpassen en filters kunt toepassen',
+  'Android Face Detection app': 'Android-app voor gezichtsdetectie',
+  'Multi-agent 3D scene simulator with JavaScript preset scripts, built with MEAN.js':
+    'Multi-agent 3D-scènesimulator met vooraf ingestelde JavaScript-scripts, gebouwd met MEAN.js',
+
+  // Talk titles (descriptive ones; proper event names are left untranslated)
+  'Best practices and quality code - GDG Catania DevFest 2022':
+    'Best practices en codekwaliteit - GDG Catania DevFest 2022',
+  'Is synthetic voice detection research going into the right direction?':
+    'Gaat het onderzoek naar detectie van synthetische stemmen de juiste kant op?',
+  'Saturday Morning Snippets - History of Operating Systems':
+    'Saturday Morning Snippets - Geschiedenis van besturingssystemen',
+  'GenerazioneY Report - Sicily Social Network Report':
+    'GenerazioneY Report - Rapport over sociale netwerken in Sicilië',
+  'Linux Day - Debian-based distros': 'Linux Day - Distributies gebaseerd op Debian',
+  'Telegram Bot Talk and Workshop at the Google DevFest 2018':
+    'Telegram-bot-talk en workshop op de Google DevFest 2018',
+  'Telegram Bot Talk at the Google DevFest 2017':
+    'Telegram-bot-talk op de Google DevFest 2017',
+  'Telegram Bot Workshop - Google I/O Extended at the GDG in Catania':
+    'Telegram-bot-workshop - Google I/O Extended bij de GDG in Catania',
+};
+
+export const dictionaries: Record<Language, Dictionary> = { en, it, nl };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
+import { LanguageProvider } from './i18n/LanguageContext';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <LanguageProvider>
+      <App />
+    </LanguageProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
Introduce a lightweight i18n layer and a language switcher in the top
navigation so visitors can browse the portfolio in English, Italian, or
Dutch.

- Add src/i18n with a React context provider, useTranslation hook, and
  en/it/nl dictionaries covering all UI chrome, section content, project
  and talk titles.
- Add a LanguageSwitcher dropdown (globe icon + flag/label) to the navbar,
  available on desktop and mobile.
- Wire useTranslation into every section component (Navbar, Home, About,
  Projects, Opensource, Teachings, Publications, Events, Footer,
  Pagination).
- Persist the chosen language to localStorage, detect the browser language
  on first visit, and keep the <html lang> attribute in sync.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KvtdZyKqUYcdc8WFjeUKwH